### PR TITLE
feat: add `-n` flag to strip comments and rewrite use paths

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -50,6 +50,9 @@ EXAMPLES:
   Add the `i18nrs` component with `yew` feature:
     os add i18nrs yew
 
+  Add the `i18nrs` component with `yew` feature while stripping all docs:
+    os add -n i18nrs yew
+
 For more information, visit: https://github.com/opensass/cli
 "#
 )]
@@ -71,4 +74,8 @@ pub struct AddArgs {
 
     /// List of features to include
     pub features: String,
+
+    /// Strip all comments (e.g., ///, //, //!...) when copying source files
+    #[arg(short = 'n', long = "no-cum")]
+    pub no_cum: bool,
 }

--- a/src/cmds/add.rs
+++ b/src/cmds/add.rs
@@ -8,7 +8,7 @@ use tar::Archive;
 use tempfile::tempdir;
 use tracing::info;
 
-pub fn run_add(crate_name: &str, feature: &str) -> anyhow::Result<()> {
+pub fn run_add(crate_name: &str, feature: &str, no_cum: bool) -> anyhow::Result<()> {
     let client = SyncClient::new(
         "opensass (via crates_io_api)",
         std::time::Duration::from_millis(1000),
@@ -54,7 +54,13 @@ pub fn run_add(crate_name: &str, feature: &str) -> anyhow::Result<()> {
     let new_crate_name = crate_name.replace('-', "_");
 
     spinner.set_message("📁 Copying relevant source files...");
-    let _ = copy_relevant_files(&source_path, current_project_src, &new_crate_name, feature)?;
+    let _ = copy_relevant_files(
+        &source_path,
+        current_project_src,
+        &new_crate_name,
+        feature,
+        no_cum,
+    )?;
 
     spinner.set_message("🧩 Updating lib.rs...");
     update_pub_file(

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
     setup_logging()?;
     match args.cmd {
         Some(Command::Add(cmd)) => {
-            task::spawn_blocking(move || run_add(&cmd.name, &cmd.features)).await??;
+            task::spawn_blocking(move || run_add(&cmd.name, &cmd.features, cmd.no_cum)).await??;
         }
         None => {}
     }


### PR DESCRIPTION
- Added `-n` flag to `AddArgs` for comment stripping during file copy
- Updated `copy_relevant_files` to:
  - Copy files from subdirectory named after the feature (e.g., `yew/`, `leptos/`)
  - Exclude `{feature}.rs` from the `copied` module list and delete it after copying
  - Strip single-line and doc comments when `-n` is true
  - Rewrite `use crate::...` and `use crate::<feature>::...` to `use crate::<crate_name>::...`